### PR TITLE
Need help with creating a `Distribution` class

### DIFF
--- a/gsoc-meetings/july-14-2021.md
+++ b/gsoc-meetings/july-14-2021.md
@@ -1,0 +1,18 @@
+## Thursday, July 15, 2021
+
+#### What I worked on
+
+- Type checking in `DirichletProcess`
+- Creating `DirichletProcessMixture` to replicate analyses [here](https://docs.pymc.io/notebooks/dp_mix.html) and [here](https://nbviewer.jupyter.org/github/fonnesbeck/Bios8366/blob/master/notebooks/Section5_2-Dirichlet-Processes.ipynb).
+
+#### Specific Questions
+
+- Question from last meeting: what do we want to come out from the other end? Perhaps we can draw some inspiration from the [`dirichletprocess`](https://github.com/dm13450/dirichletprocess) R package.
+- Austin mentioned that we can build tests to retrieve the concentation parameter from weights
+- What do we want the base distribution `DirichletProcess` to do?
+- `pm.Potential` in v4: how to make it work?
+	- My understanding is that this is necessary to have a likelihood in the model (`pm.DensityDist` and `pm.Mixture` need to be refactored in v4).
+
+### Broad Questions
+
+- Advice on creating tests

--- a/notebooks/dp-mix-v4-with-error.ipynb
+++ b/notebooks/dp-mix-v4-with-error.ipynb
@@ -1,0 +1,228 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "5776b673",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You are running the v4 development version of PyMC3 which currently still lacks key features. You probably want to use the stable v3 instead which you can either install via conda or find on the v3 GitHub branch: https://github.com/pymc-devs/pymc3/tree/v3\n"
+     ]
+    }
+   ],
+   "source": [
+    "import numpy as np\n",
+    "import pymc3 as pm\n",
+    "import pandas as pd\n",
+    "\n",
+    "from aesara import tensor as at"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "138bcc7f",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time</th>\n",
+       "      <th>sunspot.year</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>1700.5</td>\n",
+       "      <td>8.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>1701.5</td>\n",
+       "      <td>18.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>1702.5</td>\n",
+       "      <td>26.7</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>1703.5</td>\n",
+       "      <td>38.3</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>1704.5</td>\n",
+       "      <td>60.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     time  sunspot.year\n",
+       "0  1700.5           8.3\n",
+       "1  1701.5          18.3\n",
+       "2  1702.5          26.7\n",
+       "3  1703.5          38.3\n",
+       "4  1704.5          60.0"
+      ]
+     },
+     "execution_count": 2,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "K = 47\n",
+    "\n",
+    "sunspot_df = pd.read_csv(\n",
+    "    pm.get_data(\"sunspot.csv\"), sep=\";\", names=[\"time\", \"sunspot.year\"], usecols=[0, 1]\n",
+    ")\n",
+    "sunspot_df.head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "f32c2cb2",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "def stick_breaking(beta):\n",
+    "    portion_remaining = at.concatenate([[1], at.cumprod(1 - beta)[:-1]])\n",
+    "\n",
+    "    return beta * portion_remaining"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "25238563",
+   "metadata": {},
+   "source": [
+    "Taken from https://nbviewer.jupyter.org/github/fonnesbeck/Bios8366/blob/master/notebooks/Section5_2-Dirichlet-Processes.ipynb"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "c2156814",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "dist() takes 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-4-e25b17fba332>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      5\u001b[0m     \u001b[0;31m# Gamma is conjugate prior to Poisson\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      6\u001b[0m     \u001b[0mlambda_\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mGamma\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"lambda_\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m300.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;36m2.0\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mshape\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mK\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m----> 7\u001b[0;31m     \u001b[0mobs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mMixture\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m\"obs\"\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPoisson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mlambda_\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobserved\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msunspot_df\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"sunspot.year\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;32m~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/pymc3/distributions/distribution.py\u001b[0m in \u001b[0;36m__new__\u001b[0;34m(cls, name, rng, dims, initval, observed, total_size, transform, *args, **kwargs)\u001b[0m\n\u001b[1;32m    205\u001b[0m         \u001b[0;31m# Create the RV without specifying initval, because the initval may have a shape\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    206\u001b[0m         \u001b[0;31m# that only matches after replicating with a size implied by dims (see below).\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m--> 207\u001b[0;31m         \u001b[0mrv_out\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mcls\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m*\u001b[0m\u001b[0margs\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mrng\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0mrng\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0minitval\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0;32mNone\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0;34m**\u001b[0m\u001b[0mkwargs\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m\u001b[1;32m    208\u001b[0m         \u001b[0mndim_actual\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mrv_out\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mndim\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m    209\u001b[0m         \u001b[0mresize_shape\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0;32mNone\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n",
+      "\u001b[0;31mTypeError\u001b[0m: dist() takes 2 positional arguments but 3 positional arguments (and 1 keyword-only argument) were given"
+     ]
+    }
+   ],
+   "source": [
+    "with pm.Model() as model:\n",
+    "    alpha = pm.Gamma(\"alpha\", 1.0, 1.0)\n",
+    "    beta = pm.Beta(\"beta\", 1, alpha, shape=K)\n",
+    "    w = pm.Deterministic(\"w\", stick_breaking(beta))\n",
+    "    # Gamma is conjugate prior to Poisson\n",
+    "    lambda_ = pm.Gamma(\"lambda_\", 300.0, 2.0, shape=K)\n",
+    "    obs = pm.Mixture(\"obs\", w, pm.Poisson.dist(lambda_), observed=sunspot_df[\"sunspot.year\"])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "b16c72aa",
+   "metadata": {},
+   "source": [
+    "Taken from https://docs.pymc.io/notebooks/dp_mix.html (code chunk 27)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "cb8d6685",
+   "metadata": {},
+   "outputs": [
+    {
+     "ename": "TypeError",
+     "evalue": "Potential() got an unexpected keyword argument 'observed'",
+     "output_type": "error",
+     "traceback": [
+      "\u001b[0;31m---------------------------------------------------------------------------\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m                                 Traceback (most recent call last)",
+      "\u001b[0;32m<ipython-input-5-8727ca84ad27>\u001b[0m in \u001b[0;36m<module>\u001b[0;34m\u001b[0m\n\u001b[1;32m      8\u001b[0m \u001b[0;34m\u001b[0m\u001b[0m\n\u001b[1;32m      9\u001b[0m     \u001b[0;31m# line below\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0;32m---> 10\u001b[0;31m     \u001b[0mobs\u001b[0m \u001b[0;34m=\u001b[0m \u001b[0mpm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPotential\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0;34m'obs'\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mw\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mpm\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mPoisson\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mdist\u001b[0m\u001b[0;34m(\u001b[0m\u001b[0mμ\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m,\u001b[0m \u001b[0mobserved\u001b[0m\u001b[0;34m=\u001b[0m\u001b[0msunspot_df\u001b[0m\u001b[0;34m[\u001b[0m\u001b[0;34m\"sunspot.year\"\u001b[0m\u001b[0;34m]\u001b[0m\u001b[0;34m.\u001b[0m\u001b[0mvalues\u001b[0m\u001b[0;34m)\u001b[0m\u001b[0;34m\u001b[0m\u001b[0;34m\u001b[0m\u001b[0m\n\u001b[0m",
+      "\u001b[0;31mTypeError\u001b[0m: Potential() got an unexpected keyword argument 'observed'"
+     ]
+    }
+   ],
+   "source": [
+    "with pm.Model() as ss_model:\n",
+    "    \n",
+    "    α = pm.Gamma('α', 1., 1.)\n",
+    "    β = pm.Beta('β', 1, α, shape=K)\n",
+    "    w = pm.Deterministic('w', stick_breaking(β))\n",
+    "    \n",
+    "    μ = pm.Uniform('μ', 0., 300., shape=K)\n",
+    "    \n",
+    "    # line below\n",
+    "    obs = pm.Potential('obs', w, pm.Poisson.dist(μ), observed=sunspot_df[\"sunspot.year\"].values)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "ebee9878",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "pymc3-dev-py38",
+   "language": "python",
+   "name": "pymc3-dev-py38"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.8.10"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/test-dp-submodule/stick-breaking-weights-rv.py
+++ b/test-dp-submodule/stick-breaking-weights-rv.py
@@ -14,7 +14,7 @@ from pymc3.distributions.distribution import Continuous
 class StickBreakingWeightsRV(RandomVariable):
     name = "stick_breaking_weights"
     ndim_supp = 1
-    ndims_params = [0]
+    ndims_params = [1]
     dtype = "floatX"
     _print_name = ("Stick-Breaking Weights", "\\operatorname{StickBreakingWeights}")
 

--- a/test-dp-submodule/stick-breaking-weights-rv.py
+++ b/test-dp-submodule/stick-breaking-weights-rv.py
@@ -61,6 +61,11 @@ class StickBreakingWeights(Continuous):
 
 
 if __name__ == "__main__":
+
+    rng = np.random.RandomState(seed=123)
+    print(stickbreakingweights.rng_fn(rng=rng, alpha=1.5, size=[5,]))
+    print("")
+
     with pm.Model() as model:
         sbw = StickBreakingWeights("test-sticks", alpha=1)
 

--- a/test-dp-submodule/stick-breaking-weights-rv.py
+++ b/test-dp-submodule/stick-breaking-weights-rv.py
@@ -16,7 +16,7 @@ class StickBreakingWeightsRV(RandomVariable):
     ndim_supp = 1
     ndims_params = [0]
     dtype = "floatX"
-    _print_name = ("Stick-Breaking W=eights", "\\operatorname{StickBreakingWeights}")
+    _print_name = ("Stick-Breaking Weights", "\\operatorname{StickBreakingWeights}")
 
     def __call__(self, alpha, size=None, **kwargs):
         return super().__call__(alpha, size=size, **kwargs)
@@ -63,7 +63,6 @@ class StickBreakingWeights(Continuous):
 if __name__ == "__main__":
     with pm.Model() as model:
         sbw = StickBreakingWeights("test-sticks", alpha=1)
-        # larry_norm = LarryNormal(name="larrynormal", mu=1, sigma=2)
 
         trace = pm.sample(1000)
         print(trace.to_dict()["posterior"]["test-sticks"][0].mean())

--- a/test-dp-submodule/stick-breaking-weights-rv.py
+++ b/test-dp-submodule/stick-breaking-weights-rv.py
@@ -1,0 +1,69 @@
+import numpy as np
+import pymc3 as pm # v4.0
+
+from aesara import tensor as at # v2.0.12
+
+import aesara, warnings
+
+from aesara.tensor.random.op import RandomVariable
+
+from pymc3.distributions.continuous import assert_negative_support
+from pymc3.distributions.distribution import Continuous
+
+
+class StickBreakingWeightsRV(RandomVariable):
+    name = "stick_breaking_weights"
+    ndim_supp = 1
+    ndims_params = [0]
+    dtype = "floatX"
+    _print_name = ("Stick-Breaking W=eights", "\\operatorname{StickBreakingWeights}")
+
+    def __call__(self, alpha, size=None, **kwargs):
+        return super().__call__(alpha, size=size, **kwargs)
+
+    @classmethod
+    def rng_fn(cls, rng, alpha, size):
+        betas = rng.beta(1, alpha, size=size)
+        sticks = np.concatenate(
+            [
+                [1],
+                np.cumprod(1 - betas[:-1]),
+            ]
+        )
+
+
+        return betas * sticks
+
+
+stickbreakingweights = StickBreakingWeightsRV()
+
+
+class StickBreakingWeights(Continuous):
+    rv_op = stickbreakingweights
+
+    @classmethod
+    def dist(cls, alpha, *args, **kwargs):
+        alpha = at.as_tensor_variable(alpha)
+
+        assert_negative_support(alpha, "alpha", "StickBreakingWeights")
+
+        return super().dist([alpha], **kwargs)
+
+    def logp(value, alpha):
+        # alpha=1, beta=alpha is confusing... need to revisit this
+        return bound(
+            at.sum(pm.Beta.logp(value, alpha=1, beta=alpha)),
+            alpha > 0,
+        )
+
+    def _distr_parameters_for_repr(self):
+        return ["alpha"]
+
+
+if __name__ == "__main__":
+    with pm.Model() as model:
+        sbw = StickBreakingWeights("test-sticks", alpha=1)
+        # larry_norm = LarryNormal(name="larrynormal", mu=1, sigma=2)
+
+        trace = pm.sample(1000)
+        print(trace.to_dict()["posterior"]["test-sticks"][0].mean())


### PR DESCRIPTION
The file outlined in this PR attempts to create a `Distribution` class for stick-breaking weights for the Dirichlet process. Weights are generated as followed:

<img width="378" alt="Screen Shot 2021-07-12 at 10 00 57 AM" src="https://user-images.githubusercontent.com/24764859/125300490-13fc4a00-e2f8-11eb-9314-3fce7eb7c54e.png">

for some alpha > 0 value. However, the code yields the following error:

```python
---------------------------------------------------------------------------
IndexError                                Traceback (most recent call last)
<ipython-input-5-07ccfca52ddd> in <module>
      1 with pm.Model() as model:
----> 2     sbw = StickBreakingWeights("test-sticks", alpha=1)
      3 
      4     trace = pm.sample(1000)
      5     print(trace.to_dict()["posterior"]["test-sticks"][0].mean())

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/pymc3/distributions/distribution.py in __new__(cls, name, rng, dims, initval, observed, total_size, transform, *args, **kwargs)
    205         # Create the RV without specifying initval, because the initval may have a shape
    206         # that only matches after replicating with a size implied by dims (see below).
--> 207         rv_out = cls.dist(*args, rng=rng, initval=None, **kwargs)
    208         ndim_actual = rv_out.ndim
    209         resize_shape = None

<ipython-input-2-b7a30db55ce6> in dist(cls, alpha, *args, **kwargs)
     35         assert_negative_support(alpha, "alpha", "StickBreakingWeights")
     36 
---> 37         return super().dist([alpha], **kwargs)
     38 
     39     def logp(value, alpha):

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/pymc3/distributions/distribution.py in dist(cls, dist_params, shape, size, initval, **kwargs)
    283         # Create the RV with a `size` right away.
    284         # This is not necessarily the final result.
--> 285         rv_out = cls.rv_op(*dist_params, size=create_size, **kwargs)
    286         rv_out = maybe_resize(
    287             rv_out,

<ipython-input-2-b7a30db55ce6> in __call__(self, alpha, size, **kwargs)
      7 
      8     def __call__(self, alpha, size=None, **kwargs):
----> 9         return super().__call__(alpha, size=size, **kwargs)
     10 
     11     @classmethod

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in __call__(self, size, name, rng, dtype, *args, **kwargs)
    321 
    322     def __call__(self, *args, size=None, name=None, rng=None, dtype=None, **kwargs):
--> 323         res = super().__call__(rng, size, dtype, *args, **kwargs)
    324 
    325         if name is not None:

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/graph/op.py in __call__(self, *inputs, **kwargs)
    269         """
    270         return_list = kwargs.pop("return_list", False)
--> 271         node = self.make_node(*inputs, **kwargs)
    272 
    273         if config.compute_test_value != "off":

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in make_node(self, rng, size, dtype, *dist_params)
    368             raise TypeError("The type of rng should be an instance of RandomStateType")
    369 
--> 370         bcast = self.compute_bcast(dist_params, size)
    371         dtype = self.dtype or dtype
    372 

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/configparser.py in res(*args, **kwargs)
     47         def res(*args, **kwargs):
     48             with self:
---> 49                 return f(*args, **kwargs)
     50 
     51         return res

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in compute_bcast(self, dist_params, size)
    285 
    286         """
--> 287         shape = self._infer_shape(size, dist_params)
    288 
    289         # Ignore `Cast`s, since they do not affect broadcastables

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in _infer_shape(self, size, dist_params, param_shapes)
    253             ndim_reps = len(shape_reps)
    254         else:
--> 255             shape_supp = self._shape_from_params(
    256                 dist_params,
    257                 param_shapes=param_shapes,

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in _shape_from_params(self, dist_params, **kwargs)
    155         Defaults to `param_supp_shape_fn`.
    156         """
--> 157         return default_shape_from_params(self.ndim_supp, dist_params, **kwargs)
    158 
    159     def rng_fn(self, rng, *args, **kwargs):

~/anaconda3/envs/pymc3-dev-py38/lib/python3.8/site-packages/aesara/tensor/random/op.py in default_shape_from_params(ndim_supp, dist_params, rep_param_idx, param_shapes)
     68     if param_shapes is not None:
     69         ref_param = param_shapes[rep_param_idx]
---> 70         return (ref_param[-ndim_supp],)
     71     else:
     72         ref_param = dist_params[rep_param_idx]

IndexError: tuple index out of range
```

Any thoughts are appreciated!